### PR TITLE
Rename package to @metamask/object-multiplex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- TypeScript typings ([#9](https://github.com/MetaMask/obj-multiplex/pull/9))
+- TypeScript typings ([#9](https://github.com/MetaMask/object-multiplex/pull/9))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @metamask/obj-multiplex
+# @metamask/object-multiplex
 
 Simple stream multiplexing for `objectMode`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# obj-multiplex
+# @metamask/obj-multiplex
 
-simple stream multiplexing for `objectMode`
+Simple stream multiplexing for `objectMode`.
 
-### usage
+## Usage
 
 ```js
 // create multiplexer

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@metamask/obj-multiplex",
+  "name": "@metamask/object-multiplex",
   "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "obj-multiplex",
+  "name": "@metamask/obj-multiplex",
   "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",


### PR DESCRIPTION
Renames the package to `@metamask/object-multiplex`. To be followed by renaming this repository to `object-multiplex`.